### PR TITLE
Use "Public Domain" license for world_magnetic_model

### DIFF
--- a/world_magnetic_model/package.xml
+++ b/world_magnetic_model/package.xml
@@ -6,7 +6,7 @@
   </description>
   <maintainer email="meyer@fsr.tu-darmstadt.de">Johannes Meyer</maintainer>
 
-  <license></license>
+  <license>Public Domain</license>
 
   <url type="website">http://www.ngdc.noaa.gov/geomag/WMM/DoDWMM.shtml</url>
 


### PR DESCRIPTION
Please do not use an empty license tag.

See: https://github.com/ros-infrastructure/bloom/pull/250

WMM is public domain:
http://www.ngdc.noaa.gov/geomag/WMM/license.shtml

Thanks
