### PR TITLE
fixed DenseBase compiler errors with Eigen 3.2.1 and clang

### DIFF
--- a/hector_pose_estimation_core/include/hector_pose_estimation/matrix.h
+++ b/hector_pose_estimation_core/include/hector_pose_estimation/matrix.h
@@ -40,6 +40,7 @@ namespace hector_pose_estimation {
   using Eigen::Dynamic;
   using Eigen::Lower;
   using Eigen::Upper;
+  using Eigen::DenseBase;
 
   typedef double ScalarType;
   typedef Eigen::DenseIndex IndexType;


### PR DESCRIPTION
This patch might fix compiler errors in OS X Mavericks (see #4).
