### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/hector_pose_estimation/src/pose_estimation_nodelet.cpp
+++ b/hector_pose_estimation/src/pose_estimation_nodelet.cpp
@@ -55,4 +55,4 @@ private:
 } // namespace hector_pose_estimation
 
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(hector_pose_estimation, PoseEstimation, hector_pose_estimation::PoseEstimationNodelet, nodelet::Nodelet)
+PLUGINLIB_EXPORT_CLASS(hector_pose_estimation::PoseEstimationNodelet, nodelet::Nodelet)


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions