### PR TITLE
remove implicit operator bool on boost::shared_ptr<>

### DIFF
--- a/hector_pose_estimation_core/include/hector_pose_estimation/input.h
+++ b/hector_pose_estimation_core/include/hector_pose_estimation/input.h
@@ -79,7 +79,7 @@ public:
     return *variance_;
   }
 
-  virtual bool hasVariance() const { return variance_; }
+  virtual bool hasVariance() const { return (variance_ != nullptr); }
   virtual Variance const &getVariance() { if (!variance_) variance_.reset(new Variance); return *variance_; }
   virtual Variance const &getVariance() const { return *variance_; }
   virtual Variance& variance() { if (!variance_) variance_.reset(new Variance); return *variance_; }

--- a/hector_pose_estimation_core/include/hector_pose_estimation/input.h
+++ b/hector_pose_estimation_core/include/hector_pose_estimation/input.h
@@ -79,7 +79,7 @@ public:
     return *variance_;
   }
 
-  virtual bool hasVariance() const { return (variance_ != nullptr); }
+  virtual bool hasVariance() const { return (variance_.get() != 0); }
   virtual Variance const &getVariance() { if (!variance_) variance_.reset(new Variance); return *variance_; }
   virtual Variance const &getVariance() const { return *variance_; }
   virtual Variance& variance() { if (!variance_) variance_.reset(new Variance); return *variance_; }

--- a/hector_pose_estimation_core/src/system/imu_model.cpp
+++ b/hector_pose_estimation_core/src/system/imu_model.cpp
@@ -51,7 +51,7 @@ GyroModel::~GyroModel()
 bool GyroModel::init(PoseEstimation& estimator, System &system, State& state)
 {
   bias_ = state.addSubState<3,3>(this, system.getName() + "_bias");
-  return bias_;
+  return (bias_ != nullptr);
 }
 
 void GyroModel::getPrior(State &state)
@@ -113,7 +113,7 @@ AccelerometerModel::~AccelerometerModel()
 bool AccelerometerModel::init(PoseEstimation& estimator, System &system, State& state)
 {
   bias_ = state.addSubState<3,3>(this, system.getName() + "_bias");
-  return bias_;
+  return (bias_ != nullptr);
 }
 
 void AccelerometerModel::getPrior(State &state)

--- a/hector_pose_estimation_core/src/system/imu_model.cpp
+++ b/hector_pose_estimation_core/src/system/imu_model.cpp
@@ -51,7 +51,7 @@ GyroModel::~GyroModel()
 bool GyroModel::init(PoseEstimation& estimator, System &system, State& state)
 {
   bias_ = state.addSubState<3,3>(this, system.getName() + "_bias");
-  return (bias_ != nullptr);
+  return (bias_.get() != 0);
 }
 
 void GyroModel::getPrior(State &state)
@@ -113,7 +113,7 @@ AccelerometerModel::~AccelerometerModel()
 bool AccelerometerModel::init(PoseEstimation& estimator, System &system, State& state)
 {
   bias_ = state.addSubState<3,3>(this, system.getName() + "_bias");
-  return (bias_ != nullptr);
+  return (bias_.get() != 0);
 }
 
 void AccelerometerModel::getPrior(State &state)


### PR DESCRIPTION
See compilation error here:
https://github.com/tu-darmstadt-ros-pkg/hector_quadrotor/issues/82

`operator bool` is now `explicit` in boost 1.55. this change will need to be made as users update boost to >=1.55